### PR TITLE
Hard to see scrollbar when using darker background color.

### DIFF
--- a/antiscroll.css
+++ b/antiscroll.css
@@ -10,6 +10,9 @@
   -webkit-border-radius: 7px;
   -moz-border-radius: 7px;
   border-radius: 7px;
+  -webkit-box-shadow: 0 0 1px #fff;
+  -moz-box-shadow: 0 0 1px #fff;
+  box-shadow: 0 0 1px #fff;
   position: absolute;
   opacity: 0;
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);


### PR DESCRIPTION
Example: http://cl.ly/0R3J1E3B3p3z033N1j3q
Completely disappeared on #000 background.

Improved: http://cl.ly/0N0q3f3v1y3b2C103r0j
I added iOS style border by box-shadow. (legacy IE is unsupported.)
