### PR TITLE
Don't resize the inner div if an axis is turned off.

### DIFF
--- a/antiscroll.js
+++ b/antiscroll.js
@@ -39,8 +39,8 @@
 
     this.inner = this.el.find('.antiscroll-inner');
     this.inner.css({
-        'width': '+=' + scrollbarSize()
-      , 'height': '+=' + scrollbarSize()
+        'width':  '+=' + (this.y ? scrollbarSize() : 0)
+      , 'height': '+=' + (this.x ? scrollbarSize() : 0)
     });
 
     this.refresh();


### PR DESCRIPTION
I found that when you turned an axis off using the {x: false} or {y: false} options, the scrollbar wouldn't scroll the inner div completely. In my case this was because the div was unnecessarily resized; I assume this is the case for everybody else. Here's a pull request fixing it. 
