### PR TITLE
antiscroll does not work with chrome Version 25.0.1323.1 dev

### DIFF
--- a/antiscroll.js
+++ b/antiscroll.js
@@ -420,15 +420,13 @@
   function scrollbarSize () {
     if (size === undefined) {
       var div = $(
-          '<div style="width:50px;height:50px;overflow:hidden;'
-        + 'position:absolute;top:-200px;left:-200px;"><div style="height:100px;">'
+          '<div class="antiscroll-inner" style="width:50px;height:50px;overflow-y:scroll;'
+        + 'position:absolute;top:-200px;left:-200px;"><div style="height:100px;width:100%">'
         + '</div>'
       );
 
       $('body').append(div);
-
-      var w1 = $('div', div).innerWidth();
-      div.css('overflow-y', 'scroll');
+      var w1 = $(div).innerWidth();
       var w2 = $('div', div).innerWidth();
       $(div).remove();
 


### PR DESCRIPTION
Antiscroll stopped working properly in Chrome v25 (it's still in dev channel). For some reason native scrollbars are displayed under the antiscroll generated scrollbars. The browser behaves as if ::scrollbar pseudo class styles (setting scrollbar width/height to 0) were ignored.

![antiscroll in chrome v25](https://raw.github.com/gist/4109074/5220ec90449e2bc5342e389b02a1e7e1ca4a6c6c/antiscroll-chrome-v25.png)

I am not really sure what's causing that, but when trying to investigate the problem I realized that scrollbarSize did not work properly in Chrome. It was returning 0 and not the native scrollbar width.

We now calculate the size in the container with 'antiscroll-inner' classapplied. If ::scrollbar CSS is applied properly the width is 0, and we don't have to hide native scrollbars manually. Otherwise scrollbars are hidden by adjusting .antiscroll-inner size.

That fixes Chrome v25 issue.
