### PR TITLE
Updating demo to use current antiscroll.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
 
     <script src="deps/jquery.js"></script>
     <script src="deps/jquery-mousewheel.js"></script>
-    <script src="antiscroll.js"></script>
+    <script src="https://raw.github.com/LearnBoost/antiscroll/master/antiscroll.js"></script>
 
     <script>
       $(function () {


### PR DESCRIPTION
The demo seems broken on Chrome 25.0.1364.172 (it shows both native and antiscroll). Updating the reference to the current antiscroll.js (from the master branch) solves it.
