### PR TITLE
Reverting c8d8f44 (PR #53) to fix demo (issue #60)

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
 
     <script src="deps/jquery.js"></script>
     <script src="deps/jquery-mousewheel.js"></script>
-    <script src="https://raw.github.com/LearnBoost/antiscroll/master/antiscroll.js"></script>
+    <script src="antiscroll.js"></script>
 
     <script>
       $(function () {


### PR DESCRIPTION
This fixes the demo in Chrome and IE by loading antiscroll.js from learnboost.github.io instead of from raw.github.com.

It's also important to make sure that the latest version of antiscroll.js is published to the antiscroll Github Page. I'm not entirely sure how to do that.
