### PR TITLE
removing comment that mistakes standards compliance for a bug

### DIFF
--- a/antiscroll.css
+++ b/antiscroll.css
@@ -44,14 +44,6 @@
   overflow: scroll;
 }
 
-/** A bug in Chrome 25 on Lion requires each selector to have their own
-    blocks. E.g. the following:
-
-    .antiscroll-inner::-webkit-scrollbar, .antiscroll-inner::scrollbar {...}
-
-    causes the width and height rules to be ignored by the browser resulting
-    in both native and antiscroll scrollbars appearing at the same time.
- */
 .antiscroll-inner::-webkit-scrollbar {
   width: 0;
   height: 0;


### PR DESCRIPTION
The following quote from [Selectors Level 3: 5. Groups of Selectors](http://www.w3.org/TR/css3-selectors/#grouping) explains Chrome's behavior:

> **Warning:** the equivalence is true in this example because all the selectors are valid selectors. If just one of these selectors were invalid, the entire group of selectors would be invalid.
